### PR TITLE
Add upgrading for archive install

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,6 +31,7 @@ class vault::config {
       owner   => $vault::user,
       group   => $vault::group,
       mode    => $vault::config_mode,
+      notify  => Class['vault::service'],
     }
 
     # If manage_storage_dir is true and a file or raft storage backend is

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -166,19 +166,32 @@ describe 'vault' do
         context 'when installed from archive' do
           let(:params) { { install_method: 'archive' } }
 
-          it {
+          it do
             is_expected.to contain_archive('/tmp/vault.zip')
               .that_comes_before('File[vault_binary]')
-          }
+
+            is_expected.to contain_file('/opt/vault-1.4.2')
+              .with_ensure('directory')
+          end
 
           context 'when installed with default download options' do
             let(:params) do
-              super().merge(version: '0.7.0')
+              super().merge(
+                version: '0.7.0',
+              )
             end
 
             it {
+              is_expected.to contain_file('/opt/vault-0.7.0')
+
               is_expected.to contain_archive('/tmp/vault.zip')
                 .with_source('https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip')
+
+              # A regex is used to validate the command because vault bin_dir is OS specific
+              is_expected.to contain_exec('install_versioned_vault')
+                .with_command(%r{/bin/cp -f /opt/vault-0.7.0/vault /[\w/]+/vault})
+                .with_refreshonly(true)
+                .that_notifies(['Class[vault::service]'])
             }
           end
 
@@ -193,6 +206,7 @@ describe 'vault' do
             end
 
             it {
+              is_expected.to contain_file('/opt/vault-0.6.0')
               is_expected.to contain_archive('/tmp/vault.zip')
                 .with_source('http://my_site.example.com/vault/0.6.0/vaultbinary_0.6.0_linux_amd64.tar.gz')
             }


### PR DESCRIPTION
* Add ability to upgrade archive-style installs (i.e., installing from a tarball or ZIP)
* Add restart of `Service[vault]` when Vault’s config changes