### PR TITLE
Fix manage_file_capabilities

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,7 +56,7 @@ class vault::install {
     }
 
     if $vault::install_method == 'repo' {
-      Package['vault'] ~> File_capability['vault_binary_capability']
+      Package[$vault::package_name] ~> File_capability['vault_binary_capability']
     }
   }
 

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -293,6 +293,16 @@ describe 'vault' do
 
             it { is_expected.to contain_file_capability('vault_binary_capability') }
             it { is_expected.to contain_package('vault').that_notifies(['File_capability[vault_binary_capability]']) }
+
+            context 'when the package name is not "vault"' do
+              let(:params) do
+                super().merge(
+                  package_name: 'custom',
+                )
+              end
+
+              it { is_expected.to contain_package('custom') }
+            end
           end
         end
       end


### PR DESCRIPTION
## SUMMARY

Fixes a bug where `$manage_file_capabilities` is true and `$package_name` is a custom name (i.e., not `'vault'`)

See jsok/puppet-vault#157

## TESTS/SPECS

Add a context to test a custom package name when `$manage_file_capabilities = true`