### PR TITLE
make header in systemd service file configurable, with sane default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,8 @@
 # @param extra_config
 #   Hash representation of any additional Vault configuration not already represented
 #
+# @param vault_template_header
+#   String for text placed in the header of template files
 class vault (
   String   $user                              = $vault::params::user,
   Boolean  $manage_user                       = $vault::params::manage_user,
@@ -201,6 +203,7 @@ class vault (
   String   $version                           = $vault::params::version,
   String   $os_type                           = $vault::params::os_type,
   String   $arch                              = $vault::params::arch,
+  String   $vault_template_header             = $vault::params::vault_template_header,
   Optional[Boolean] $enable_ui                = $vault::params::enable_ui,
   Optional[String] $api_addr                  = undef,
   Hash     $extra_config                      = {},

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,4 +78,6 @@ class vault::params {
     }
   }
   $os_type = downcase($facts['kernel'])
+
+  $vault_template_header = "This file is managed by the ${module_name} module. Modifications will be lost."
 }

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -1,8 +1,6 @@
-# vault systemd unit file
 ###########################################################################################################
-# this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
-# any changes will be overwritten if Puppet is run again
-# This script is originally from:
+# <%= scope['vault::vault_template_header'] %>
+# This service file is based on:
 # https://learn.hashicorp.com/vault/operations/ops-deployment-guide#step-3-configure-systemd
 ###########################################################################################################
 


### PR DESCRIPTION
## SUMMARY

Create a parameter that makes the template header configurable. Modify what was already there to be a bit simpler and saner.

In our environment, we have a global Puppet template header string that is set in _all_ files generated by Puppet templates. We will actually be overriding the default I've put in this commit in our environment, because we have something that is more specific to us. I've already tested it without the override, and with the override in hieradata which looks something like this:

`vault::vault_template_header: "%{::puppet_template_header}"`
